### PR TITLE
fix: left/right arrow key mapping in character selection

### DIFF
--- a/src/input.c
+++ b/src/input.c
@@ -25,10 +25,10 @@ void HandleInput(Game *game) {
     };
     break;
   case CHAR_SELECT_MENU:
-    if (IsKeyPressed(KEY_A) || IsKeyPressed(KEY_RIGHT)) {
+    if (IsKeyPressed(KEY_A) || IsKeyPressed(KEY_LEFT)) {
       PrevChar(game);
     }
-    if (IsKeyPressed(KEY_D) || IsKeyPressed(KEY_LEFT)) {
+    if (IsKeyPressed(KEY_D) || IsKeyPressed(KEY_RIGHT)) {
       NextChar(game);
     }
     if (IsKeyPressed(KEY_ENTER)) {


### PR DESCRIPTION
Previously, the left arrow key was mapped to NextChar() and right arrow to PrevChar(), making the character selection navigation counterintuitive.